### PR TITLE
css及びscssファイルに対してコードフォーマットをかける

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint --fix"
+    "*.{js,jsx,ts,tsx}": "eslint --fix",
+    "*.{css,scss}": "stylelint --fix"
   },
   "devDependencies": {
     "@storybook/addon-actions": "5.3.18",


### PR DESCRIPTION
close #69

stylelintもprettier使ってみようかと思ったが、やってみたところせっかく前に設定したstylelintの内容が打ち消されてしまうようなものだったので素のstylelintでコードフォーマットをかけるようにする。